### PR TITLE
seo: Add `<link rel="canonical">` to every page

### DIFF
--- a/.vitepress/config/index.mts
+++ b/.vitepress/config/index.mts
@@ -5,6 +5,9 @@ import en from './en.mts'
 import zh_cn from './zh-CN.mts'
 import zh_hk from './zh-HK.mts'
 
+// 站点部署的源站域名，用于生成 <link rel="canonical">
+const SITE_ORIGIN = 'https://longbridge.com'
+
 export default defineConfig({
   base: '/desktop/',
   srcDir: 'docs',
@@ -40,6 +43,20 @@ export default defineConfig({
     root: { label: 'English', ...en },
     'zh-CN': { label: '简体中文', ...zh_cn },
     'zh-HK': { label: '繁體中文', ...zh_hk }
+  },
+  transformPageData(pageData, { siteConfig }) {
+    const pagePath = pageData.relativePath
+      .replace(/(^|\/)index\.md$/, '$1')
+      .replace(/\.md$/, siteConfig.cleanUrls ? '' : '.html')
+
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.push([
+      'link',
+      {
+        rel: 'canonical',
+        href: `${SITE_ORIGIN}${siteConfig.site.base}${pagePath}`
+      }
+    ])
   },
   transformHead({ assets }) {
     const h1Font = assets.find(asset =>


### PR DESCRIPTION
## 变更

通过 VitePress 的 `transformPageData` 钩子给每个页面注入 `<link rel="canonical">`，href 为该页面的完整线上 URL。

- 源站域名用常量 `SITE_ORIGIN`（`https://longbridge.com`）；base（`/desktop/`）和 `cleanUrls` 从 `siteConfig` 读取，改站点配置无需同步改这段代码。
- 路径规则与 VitePress 自身生成 sitemap 的逻辑一致：`index.md` 去掉文件名保留结尾斜杠，其余去掉 `.md`（因为 `cleanUrls: true`，不带 `.html`）。
- 三个 locale（root / `zh-CN` / `zh-HK`）自动覆盖。

## 验证

本地 `bun run build`：301 个 HTML 中 300 个含 canonical，唯一没有的是 VitePress 内置的 `404.html`（无对应 md，本就不应有 canonical）。抽样：

| 页面 | canonical |
|---|---|
| `dist/index.html` | `https://longbridge.com/desktop/` |
| `dist/release-notes/index.html` | `https://longbridge.com/desktop/release-notes/` |
| `dist/zh-CN/index.html` | `https://longbridge.com/desktop/zh-CN/` |
| `dist/zh-HK/release-notes/v0.18.4.html` | `https://longbridge.com/desktop/zh-HK/release-notes/v0.18.4` |
| `dist/release-notes/preview/v0.19.0-preview.0.html` | `https://longbridge.com/desktop/release-notes/preview/v0.19.0-preview.0` |

## 待确认

目录首页的 canonical 带结尾斜杠（`/desktop/release-notes/`），而站内导航链接是不带斜杠的 `/desktop/release-notes`。这与 VitePress sitemap 的约定一致，但如果 OSS/CDN 对两种形式都直接返回内容（而非 301 归一），搜索引擎会看到两个 URL —— canonical 指向带斜杠那个，抓取上没问题。若希望统一成不带斜杠可以调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)