### PR TITLE
home: Promote `install.sh` for Linux and drop AppImage

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config --global user.name "AutoBot"
-          git config --global user.email "bot@users.noreply.github.com"
+          git config --global user.name "Floyd Wang"
+          git config --global user.email "codelife721@gmail.com"
 
       - name: Create PR
         run: |

--- a/.vitepress/locales/en.ts
+++ b/.vitepress/locales/en.ts
@@ -2,6 +2,9 @@ export default {
   name: 'Longbridge Pro',
   tagline: 'Faster, smoother, more efficient',
   download_more: 'View all versions',
+  install_pkg_label: 'Or download the installer:',
+  install_sh_copy: 'Copy command',
+  install_sh_copied: 'Copied',
   legacy_info: `We're constantly improving and optimizing the features in this latest version. <br />For access to more complete functionality, feel free to <a href="https://longbridge.com/download" target="_blank">download the previous version.</a>`,
   features: [
     {

--- a/.vitepress/locales/zh-CN.ts
+++ b/.vitepress/locales/zh-CN.ts
@@ -2,6 +2,9 @@ export default {
   name: 'Longbridge Pro',
   tagline: '全新的专业证券交易桌面端，更专业、更流畅、更高效',
   download_more: '查看更多版本',
+  install_pkg_label: '或下载安装包：',
+  install_sh_copy: '复制命令',
+  install_sh_copied: '已复制',
   legacy_info:
     '当前为全新一代版本，功能正在持续优化和完善中，如需更完整的功能，可选择 <a href="https://longbridge.com/download" target="_blank">下载上一代版本</a>',
   features: [

--- a/.vitepress/locales/zh-HK.ts
+++ b/.vitepress/locales/zh-HK.ts
@@ -2,6 +2,9 @@ export default {
   name: 'Longbridge Pro',
   tagline: '全新的專業證券交易桌面端，更專業、更流暢、更高效',
   download_more: '查看更多版本',
+  install_pkg_label: '或下載安裝包：',
+  install_sh_copy: '複製命令',
+  install_sh_copied: '已複製',
   legacy_info:
     '當前為全新一代版本，功能正在持續優化和完善中，如需更完整的功能，可選擇 <a href="https://longbridge.com/download" target="_blank">下載上一代</a>',
   features: [

--- a/docs/pages/home/DownloadInfo.vue
+++ b/docs/pages/home/DownloadInfo.vue
@@ -1,12 +1,31 @@
 <script setup>
-import { computed, onMounted } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { getDownloads, getPlatform, useLocale } from "../utils";
 
-const { download_more, legacy_info } = useLocale();
+const { download_more, legacy_info, install_sh_copy, install_sh_copied, install_pkg_label } = useLocale();
 
 const version = import.meta.env.VERSION || "v0.1.30";
 
 const downloads = computed(() => getDownloads(version));
+
+const INSTALL_SH_COMMAND = "curl -fsSL https://longbridge.com/desktop/install.sh | sh";
+const copied = ref(false);
+
+const copyInstallCommand = async () => {
+    try {
+        await navigator.clipboard.writeText(INSTALL_SH_COMMAND);
+    } catch {
+        // Clipboard API unavailable (e.g. insecure context), fall back
+        const textarea = document.createElement("textarea");
+        textarea.value = INSTALL_SH_COMMAND;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        textarea.remove();
+    }
+    copied.value = true;
+    setTimeout(() => (copied.value = false), 2000);
+};
 
 onMounted(() => {
     const platform = getPlatform();
@@ -17,7 +36,7 @@ onMounted(() => {
                 btn.classList.add("active");
             });
     } else {
-        document.querySelectorAll(".btn-download").forEach((btn) => {
+        document.querySelectorAll("[data-platform]").forEach((btn) => {
             btn.classList.add("active");
         });
     }
@@ -25,6 +44,31 @@ onMounted(() => {
 </script>
 <template>
     <div>
+        <div class="install-sh hidden flex-col items-center gap-4 mb-4 px-4" data-platform="linux">
+            <div
+                class="flex items-center gap-2 max-w-full rounded-md border border-[var(--vp-c-divider)] bg-[var(--vp-c-bg-soft)] py-2 pl-4 pr-2 font-mono text-sm">
+                <code
+                    class="whitespace-nowrap overflow-x-auto text-[var(--vp-c-text-1)] !bg-transparent !p-0 !rounded-none"><span class="text-[var(--lb-gray-1)] select-none">$ </span>{{ INSTALL_SH_COMMAND }}</code>
+                <button type="button"
+                    class="flex shrink-0 items-center justify-center w-7 h-7 rounded cursor-pointer transition-colors duration-200 hover:bg-[var(--vp-c-default-soft)]"
+                    :class="copied ? 'text-green-600' : 'text-[var(--lb-gray-1)]'"
+                    :title="copied ? install_sh_copied : install_sh_copy"
+                    :aria-label="copied ? install_sh_copied : install_sh_copy" @click="copyInstallCommand">
+                    <svg v-if="copied" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+                        <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                            stroke-width="2" d="M5 12l5 5L20 7" />
+                    </svg>
+                    <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+                        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                            stroke-width="2">
+                            <rect width="13" height="13" x="9" y="9" rx="2" />
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                        </g>
+                    </svg>
+                </button>
+            </div>
+            <p class="text-sm text-[var(--lb-gray-1)]">{{ install_pkg_label }}</p>
+        </div>
         <div class="flex flex-wrap items-center gap-4 justify-center mb-5 lt-sm:(flex-col [&>a]:(w-35%))">
             <template v-for="link in downloads">
                 <a :href="link.url"
@@ -90,5 +134,9 @@ onMounted(() => {
 .btn-download.active {
     display: flex;
     align-items: center;
+}
+
+.install-sh.active {
+    display: flex;
 }
 </style>

--- a/docs/pages/utils.test.ts
+++ b/docs/pages/utils.test.ts
@@ -51,12 +51,6 @@ describe("createDownloadUrl", () => {
     );
   });
 
-  test("should create Linux AppImage download URL", () => {
-    expect(createDownloadUrl("1.0.0", "linux", "x86_64", "appimage")).toBe(
-      "https://assets.lbctrl.com/github/release/longbridge-desktop/stable/longbridge-1.0.0-linux-x86_64.AppImage"
-    );
-  });
-
   test("should create Linux deb download URL", () => {
     expect(createDownloadUrl("1.0.0", "linux", "x86_64", "deb")).toBe(
       "https://assets.lbctrl.com/github/release/longbridge-desktop/stable/longbridge-1.0.0-linux-x86_64.deb"
@@ -67,7 +61,7 @@ describe("createDownloadUrl", () => {
 describe("getDownloads", () => {
   test("all platform", () => {
     const downloads = getDownloads("1.0.0");
-    expect(downloads).toHaveLength(5);
+    expect(downloads).toHaveLength(4);
     expect(downloads[0]).toEqual({
       text: "Windows",
       suffix: "x86_64",
@@ -87,12 +81,6 @@ describe("getDownloads", () => {
       platform: "macos",
     });
     expect(downloads[3]).toEqual({
-      text: "Linux",
-      suffix: "AppImage",
-      url: "https://assets.lbctrl.com/github/release/longbridge-desktop/stable/longbridge-1.0.0-linux-x86_64.AppImage",
-      platform: "linux",
-    });
-    expect(downloads[4]).toEqual({
       text: "Linux",
       suffix: "deb",
       url: "https://assets.lbctrl.com/github/release/longbridge-desktop/stable/longbridge-1.0.0-linux-x86_64.deb",

--- a/docs/pages/utils.ts
+++ b/docs/pages/utils.ts
@@ -51,7 +51,7 @@ export const createDownloadUrl = (
   version: string,
   os: "windows" | "macos" | "linux",
   arch: 'x86_64' | 'aarch64' | 'arm64',
-  suffix: "appimage" | "deb" | "" = ""
+  suffix: "deb" | "" = ""
 ) => {
   const baseUrl =
     "https://assets.lbctrl.com/github/release/longbridge-desktop/stable";
@@ -61,7 +61,6 @@ export const createDownloadUrl = (
     macos: `macos-${arch}.dmg`,
     linux: {
       deb: `linux-${arch}.deb`,
-      appimage: `linux-${arch}.AppImage`,
     },
   };
 
@@ -92,12 +91,6 @@ export const getDownloads = (version: string) => {
         url: createDownloadUrl(version, "linux", "x86_64", "deb"),
         platform: "linux",
       },
-      {
-        text: "Linux",
-        suffix: "AppImage",
-        url: createDownloadUrl(version, "linux", "x86_64", "appimage"),
-        platform: "linux",
-      }
     ],
     macos: [
       {


### PR DESCRIPTION
## Summary

- Linux download section now leads with the shell installer (styled after [zed.dev/download](https://zed.dev/download)):
  `curl -fsSL https://longbridge.com/desktop/install.sh | sh` shown in a mono command block with a copy button (flips to a green check for 2s)
- An "Or download the installer:" hint sits between the command block and the deb button
- Removed the deprecated AppImage download (`createDownloadUrl`, `getDownloads`, tests)
- New locale strings (`install_pkg_label`, `install_sh_copy`, `install_sh_copied`) in en / zh-CN / zh-HK
- Generate Version workflow: branch commits are now authored by a real GitHub account instead of the unlinked "AutoBot" identity

The command block shares the existing UA-based platform detection: Linux visitors see it above the deb button; Windows/macOS visitors don't see it; unknown platforms see everything. Both the hero and the bottom CTA reuse `DownloadInfo.vue`, so they update together.

Note: the inner `<code>` background is forced transparent and spacing uses flex `gap` because un-layered base styles (`p { margin: 0 }`, theme `code` background) override UnoCSS layer utilities.

## Test plan

- [x] `bun run build` passes
- [x] Headless Chromium checks: Linux UA shows command block + deb; macOS UA hides it; unknown UA shows all; clipboard receives the exact command; 375px viewport doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)